### PR TITLE
Updated stamp creation to leverage the retry helper method

### DIFF
--- a/src/ProcessStamp.php
+++ b/src/ProcessStamp.php
@@ -3,10 +3,10 @@
 namespace OrisIntel\ProcessStamps;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\DB;
 
 class ProcessStamp extends Model
 {
@@ -42,6 +42,8 @@ class ProcessStamp extends Model
      * @param null|string $hash
      *
      * @return ProcessStamp
+     *
+     * @throws ModelNotFoundException
      */
     public static function firstOrCreateByProcess(array $process, ?string $hash = null) : self
     {
@@ -59,23 +61,31 @@ class ProcessStamp extends Model
             $parent = static::firstOrCreateByProcess(static::getProcessName($process['type'], $process['parent_name']));
         }
 
-        $stamp = static::where('hash', $hash)->first();
+        return retry(4, function() use ($hash, $process, $parent) {
+            $stamp = static::firstWhere('hash', $hash);
 
-        /*
-         * If stamp does not exist in the database yet, go ahead and obtain a lock to create it.
-         * This specifically doesn't lock as the first step to avoid all calls obtaining a lock from the cache if the item already exists in the DB.
-         */
-        if (! $stamp) {
-            Cache::lock('process-stamps-hash-create-' . $hash, 10)->get(function () use (&$stamp, $hash, $process, $parent) {
-                $stamp = static::firstOrCreate(['hash' => $hash], [
-                    'name'      => trim($process['name']),
-                    'type'      => $process['type'],
-                    'parent_id' => optional($parent)->getKey(),
-                ]);
-            });
-        }
+            /*
+             * If stamp does not exist in the database yet, go ahead and obtain a lock to create it.
+             * This specifically doesn't lock as the first step to avoid all calls obtaining a lock from the cache if
+             * the item already exists in the DB.
+             */
+            if (! $stamp) {
+                Cache::lock('process-stamps-hash-create-' . $hash, 10)
+                    ->get(function () use (&$stamp, $hash, $process, $parent) {
+                        $stamp = static::firstOrCreate(['hash' => $hash], [
+                            'name'      => trim($process['name']),
+                            'type'      => $process['type'],
+                            'parent_id' => optional($parent)->getKey(),
+                        ]);
+                    });
+            }
 
-        return $stamp;
+            if (null === $stamp) {
+                throw new ModelNotFoundException();
+            }
+
+            return $stamp;
+        }, 25);
     }
 
     /**


### PR DESCRIPTION
Issue
When multiple requests happen (AJAX Async processing) and they will all have the same process hash the first request will work, some subset of following requests will fail, then the rest will work. This happens because if the hash doesn't already exist we block via a cache lock. This then returns a null instance for the subsequent requests until the record is created.

Solution
Updated the firstOrCreate method to use the retry helper. Now when a null instance would be returned instead we'll throw an exception and retry both finding the instances in the DB and checking on the Cache::lock.

I tried to set sane starting values (25ms sleep and 4 total retries) which should be well enough for most instances to create a single DB records (100ms total)

Release notes
Better handling of stamp creation to support high concurrency