### PR TITLE
Updated process name to get job that horizon is processing

### DIFF
--- a/src/ProcessStamp.php
+++ b/src/ProcessStamp.php
@@ -171,12 +171,11 @@ class ProcessStamp extends Model
                     foreach (debug_backtrace() as $step) {
                         if (str_ends_with($step['class'], 'CallQueuedHandler')) {
                             foreach ($step['args'] as $arg) {
-                                if (is_object($arg) && property_exists($arg, 'commandName')) {
-                                    $command_name_parts = explode('\\', $arg->commandName);
-                                    $name = array_pop($command_name_parts);
-                                    break 2;
-                                } elseif (is_array($arg) && array_key_exists('commandName', $arg)) {
-                                    $command_name_parts = explode('\\', $arg['commandName']);
+                                if (
+                                    (is_object($arg) && $command_name = $arg->commandName ?? null )
+                                    || (is_array($arg) && $command_name = $arg['commandName'] ?? null )
+                                ) {
+                                    $command_name_parts = explode('\\', $command_name);
                                     $name = array_pop($command_name_parts);
                                     break 2;
                                 }

--- a/src/ProcessStamp.php
+++ b/src/ProcessStamp.php
@@ -166,6 +166,24 @@ class ProcessStamp extends Model
             case 'artisan':
                 $name = ($raw_process ?? implode(' ', array_slice($_SERVER['argv'], 1)));
                 $parent_name = static::getParentArtisan($name);
+
+                if (str_starts_with($name, 'horizon')) {
+                    foreach (debug_backtrace() as $step) {
+                        if (str_ends_with($step['class'], 'CallQueuedHandler')) {
+                            foreach ($step['args'] as $arg) {
+                                if (is_object($arg) && property_exists($arg, 'commandName')) {
+                                    $command_name_parts = explode('\\', $arg->commandName);
+                                    $name = array_pop($command_name_parts);
+                                    break 2;
+                                } elseif (is_array($arg) && array_key_exists('commandName', $arg)) {
+                                    $command_name_parts = explode('\\', $arg['commandName']);
+                                    $name = array_pop($command_name_parts);
+                                    break 2;
+                                }
+                            }
+                        }
+                    }
+                }
                 break;
 
             case 'file':

--- a/src/ProcessStamp.php
+++ b/src/ProcessStamp.php
@@ -171,10 +171,7 @@ class ProcessStamp extends Model
                     foreach (debug_backtrace() as $step) {
                         if (str_ends_with($step['class'], 'CallQueuedHandler')) {
                             foreach ($step['args'] as $arg) {
-                                if (
-                                    (is_object($arg) && $command_name = $arg->commandName ?? null )
-                                    || (is_array($arg) && $command_name = $arg['commandName'] ?? null )
-                                ) {
+                                if ($command_name = json_decode(json_encode($arg), true)['commandName'] ?? null) {
                                     $command_name_parts = explode('\\', $command_name);
                                     $name = array_pop($command_name_parts);
                                     break 2;


### PR DESCRIPTION
Updated the getProcessName method to resolve horizon tasks to the job that it is processing.

That leads to this value
```
horizon:work redis --name=default --supervisor=ip-123-45-678-90-Pspg:supervisor-1 --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue=default --sleep=3 --timeout=60 --tries=1
```
becoming this
```
ProcessImportFileJob
```